### PR TITLE
fix: mark vm require(esm) results with __esModule (fix #11161)

### DIFF
--- a/packages/vitest/src/runtime/external-executor.ts
+++ b/packages/vitest/src/runtime/external-executor.ts
@@ -119,6 +119,7 @@ export class ExternalModulesExecutor {
   }
 
   #esmSyntaxCache = new Map<string, boolean>()
+  #esmRequireCompatNamespaces = new Map<string, Record<string, unknown>>()
 
   // require() dispatches to the sync ESM loader only for files that are
   // explicitly marked as ESM (.mjs or a "type": "module" package scope).
@@ -154,9 +155,21 @@ export class ExternalModulesExecutor {
     const namespace = module.namespace as Record<string, unknown>
     // Node parity: an ES module can define its own require() result with an
     // export named "module.exports"
-    return 'module.exports' in namespace
-      ? namespace['module.exports']
-      : namespace
+    if ('module.exports' in namespace) {
+      return namespace['module.exports']
+    }
+    // Node marks require(esm) results with __esModule so CJS interop helpers
+    // (Babel/Rollup `interopRequireDefault`) treat them as transpiled ESM.
+    // The vm module namespace is sealed, so expose a cached copy instead.
+    let compatNamespace = this.#esmRequireCompatNamespaces.get(url)
+    if (!compatNamespace) {
+      compatNamespace = { __esModule: true }
+      for (const key of Object.keys(namespace)) {
+        compatNamespace[key] = namespace[key]
+      }
+      this.#esmRequireCompatNamespaces.set(url, compatNamespace)
+    }
+    return compatNamespace
   }
 
   public resolveSyncSpecifier = (

--- a/test/e2e/test/vm-threads.test.ts
+++ b/test/e2e/test/vm-threads.test.ts
@@ -269,6 +269,14 @@ test.skipIf(!supportsRequireEsm).for(['vmThreads', 'vmForks'] as const)(
         exports: './index.mjs',
       }),
       'node_modules/esm-pkg-2/index.mjs': 'export const state = { name: "esm-pkg-2" }',
+      'esm-scope/interop-dep.mjs': 'export default function impl() {}',
+      'esm-scope/interop-consumer.cjs': [
+        "'use strict'",
+        "var dep = require('./interop-dep.mjs')",
+        "function _interopDefault(e) { return e && e.__esModule ? e : { default: e } }",
+        "var dep__default = _interopDefault(dep)",
+        "module.exports = { hasMarker: '__esModule' in dep, defaultType: typeof dep__default.default }",
+      ].join('\n'),
       'require-esm.test.js': `
         import { createRequire } from 'node:module'
         import { expect, test } from 'vitest'
@@ -356,6 +364,18 @@ test.skipIf(!supportsRequireEsm).for(['vmThreads', 'vmForks'] as const)(
           const imported = await import('esm-pkg-2')
           const required = require('esm-pkg-2')
           expect(required.state).toBe(imported.state)
+        })
+
+        test('marks the namespace with __esModule for CJS interop helpers', () => {
+          const ns = require('./esm-scope/entry.mjs')
+          expect(ns.__esModule).toBe(true)
+          expect(typeof ns.default).toBe('string')
+        })
+
+        test('require(esm) result interoperates with transpiled CJS helpers', () => {
+          const result = require('./esm-scope/interop-consumer.cjs')
+          expect(result.hasMarker).toBe(true)
+          expect(result.defaultType).toBe('function')
         })
       `,
     }, {


### PR DESCRIPTION
Fixes #11161.

### Problem

In the `vmThreads` / `vmForks` pools, `require()` of an ES module returns the raw vm module namespace, missing the `__esModule: true` marker Node adds to `require(esm)` results. CJS interop helpers emitted by Babel/Rollup (`_interopDefault`), used by thousands of published packages, then wrap the namespace instead of reading `.default`, producing `_interopDefault(...).default is not a function`.

Verified on vitest 5.0.0 with the issue's dual-package repro (a `module-sync` conditional export resolving to an `.mjs` default export):

| runner | `'__esModule' in dep` | `typeof _interopDefault(dep).default` |
| --- | --- | --- |
| plain `node` / `threads` / `forks` | `true` | `function` |
| `vmThreads` / `vmForks` | `false` | `object` |

### Fix

`packages/vitest/src/runtime/external-executor.ts`: when `require(esm)` resolves, return a namespace marked with `__esModule: true` like Node does. The vm module namespace is sealed, so a cached copy is exposed per module — this also keeps `require()` of the same module returning the same object (existing behavior asserted by the tests).

The `module.exports` named-export escape hatch is left untouched.

### Tests

Extended the require(esm) e2e coverage in `test/e2e/test/vm-threads.test.ts` for both `vmThreads` and `vmForks`:
- the namespace carries `__esModule`
- a CJS consumer using a Babel/Rollup-style `_interopDefault` helper reads the function default export

---

AI disclosure: code prepared with Codex (AI) and reviewed/approved by a human contributor before opening.
