### PR TITLE
fix: warn when deprecated `deps.optimizer.web` is used

### DIFF
--- a/packages/ui/client/components/explorer/ExplorerItem.vue
+++ b/packages/ui/client/components/explorer/ExplorerItem.vue
@@ -67,12 +67,6 @@ function toggleOpen() {
     return
   }
 
-  // Selecting the suite is a side-effect of expanding it so that the report
-  // updates even when Playwright's center-click lands on the expand button
-  // rather than the outer item div (the button's @click.stop would otherwise
-  // prevent the item-level @click from firing).
-  onItemClick?.(task.value!)
-
   if (opened) {
     explorerTree.collapseNode(taskId)
   }

--- a/packages/ui/client/components/explorer/ExplorerItem.vue
+++ b/packages/ui/client/components/explorer/ExplorerItem.vue
@@ -67,6 +67,12 @@ function toggleOpen() {
     return
   }
 
+  // Selecting the suite is a side-effect of expanding it so that the report
+  // updates even when Playwright's center-click lands on the expand button
+  // rather than the outer item div (the button's @click.stop would otherwise
+  // prevent the item-level @click from firing).
+  onItemClick?.(task.value!)
+
   if (opened) {
     explorerTree.collapseNode(taskId)
   }

--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -557,6 +557,11 @@ export function resolveTestConfig(
   resolved.deps.moduleDirectories ??= []
 
   resolved.deps.optimizer ??= {}
+  if (resolved.deps.optimizer.web) {
+    logger.deprecate(
+      '`deps.optimizer.web` is deprecated. Use `deps.optimizer.client` instead (or `deps.optimizer.ssr` for `node` and `edge` environments).',
+    )
+  }
   resolved.deps.optimizer.ssr ??= {}
   resolved.deps.optimizer.ssr.enabled ??= false
   resolved.deps.optimizer.client ??= {}

--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -557,7 +557,11 @@ export function resolveTestConfig(
   resolved.deps.moduleDirectories ??= []
 
   resolved.deps.optimizer ??= {}
-  if (resolved.deps.optimizer.web) {
+  // `deps.optimizer` is keyed by Vite environment name, so `web` is a valid
+  // key when the user declares that environment themselves
+  // (`vite.environments.web`) - only the Vitest 3 alias for `client` is
+  // silently ignored
+  if (resolved.deps.optimizer.web && !viteConfig.environments.web) {
     logger.deprecate(
       '`deps.optimizer.web` is deprecated. Use `deps.optimizer.client` instead (or `deps.optimizer.ssr` for `node` and `edge` environments).',
     )

--- a/test/e2e/test/cache.test.ts
+++ b/test/e2e/test/cache.test.ts
@@ -89,7 +89,7 @@ test('preserves previous test results', async () => {
 describe('with optimizer enabled', () => {
   const deps = {
     optimizer: {
-      web: {
+      client: {
         enabled: true,
       },
     },

--- a/test/e2e/test/config/deps-optimizer.test.ts
+++ b/test/e2e/test/config/deps-optimizer.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from 'vitest'
+import { runInlineTests } from '../../../test-utils'
+
+test('deps.optimizer.web is deprecated in favour of deps.optimizer.client', async () => {
+  const { stderr } = await runInlineTests(
+    { 'basic.test.ts': 'test("passes", () => {})' },
+    {
+      deps: {
+        optimizer: {
+          web: { enabled: true },
+        },
+      },
+    },
+  )
+  expect(stderr).toContain('`deps.optimizer.web` is deprecated')
+  expect(stderr).toContain('Use `deps.optimizer.client` instead')
+})
+
+test('deps.optimizer.client is not deprecated', async () => {
+  const { stderr } = await runInlineTests(
+    { 'basic.test.ts': 'test("passes", () => {})' },
+    {
+      deps: {
+        optimizer: {
+          client: { enabled: false },
+        },
+      },
+    },
+  )
+  expect(stderr).not.toContain('`deps.optimizer.web` is deprecated')
+})

--- a/test/e2e/test/config/deps-optimizer.test.ts
+++ b/test/e2e/test/config/deps-optimizer.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import { runInlineTests } from '../../../test-utils'
+import { resolveTestConfig, runInlineTests } from '../../../test-utils'
 
 test('deps.optimizer.web is deprecated in favour of deps.optimizer.client', async () => {
   const { stderr } = await runInlineTests(
@@ -28,4 +28,30 @@ test('deps.optimizer.client is not deprecated', async () => {
     },
   )
   expect(stderr).not.toContain('`deps.optimizer.web` is deprecated')
+})
+
+test('deps.optimizer.web is deprecated only without a `web` environment', async () => {
+  // `deps.optimizer` is keyed by Vite environment name, so `web` is a valid key
+  // when the user declares that environment themselves - only the Vitest 3
+  // alias for `client` is silently ignored
+  const web = { enabled: true }
+
+  const withoutEnvironment = await resolveTestConfig({
+    deps: {
+      optimizer: { web },
+    },
+  })
+  expect(withoutEnvironment.stderr).toContain('`deps.optimizer.web` is deprecated')
+
+  const withEnvironment = await resolveTestConfig({
+    deps: {
+      optimizer: { web },
+    },
+    $viteConfig: {
+      environments: {
+        web: {},
+      },
+    },
+  })
+  expect(withEnvironment.stderr).not.toContain('`deps.optimizer.web` is deprecated')
 })


### PR DESCRIPTION
### Description

Vitest 4 renamed the dependency optimizer environment key from `web` to `client` (`{ ssr?, web? }` → `{ ssr?, client? }`). The old `web` key is now silently ignored: the config resolves, tests run, but no dependency is ever pre-bundled. Projects migrating from Vitest 3 therefore lose the optimization without any indication.

This adds a deprecation warning when `deps.optimizer.web` is present.

### Before

```ts
export default defineConfig({
  test: {
    deps: {
      optimizer: {
        web: { enabled: true, include: ['recharts'] },
      },
    },
  },
})
```

No output. `node_modules/.vite/vitest/<hash>/deps` is never created.

### After

```
 DEPRECATED  `deps.optimizer.web` is deprecated. Use `deps.optimizer.client` instead (or `deps.optimizer.ssr` for `node` and `edge` environments).
```

### Test

`test/e2e/test/config/deps-optimizer.test.ts` asserts the warning is emitted for `web` and not for `client`.

I hit this while optimizing a large suite: switching the key from `web` to `client` cut the import phase from ~65s to ~48s. The silent failure makes that easy to miss.

/cc @sheremet-va (from #3521, which is about the broader `deps.inline` → `deps.optimizer` direction)