### PR TITLE
fix: isolate `result.status` between `repeats` runs

### DIFF
--- a/packages/vitest/src/runtime/runner/run.ts
+++ b/packages/vitest/src/runtime/runner/run.ts
@@ -616,7 +616,10 @@ async function runTest(test: Test, runner: VitestRunner): Promise<void> {
   const $ = runner.trace!
 
   const repeats = test.repeats ?? 0
+  let failedRepeatErrors: TestError[] | undefined
   for (let repeatCount = 0; repeatCount <= repeats; repeatCount++) {
+    test.result.state = 'run' as TaskState
+    test.result.errors = undefined
     const retry = getRetryCount(test.retry)
     for (let retryCount = 0; retryCount <= retry; retryCount++) {
       let beforeEachCleanups: unknown[] = []
@@ -761,6 +764,16 @@ async function runTest(test: Test, runner: VitestRunner): Promise<void> {
       // update retry info
       updateTask('test-retried', test, runner)
     }
+
+    if (test.result.state === 'fail') {
+      failedRepeatErrors ??= []
+      failedRepeatErrors.push(...test.result.errors || [])
+    }
+  }
+
+  if (failedRepeatErrors) {
+    test.result.state = 'fail'
+    test.result.errors = failedRepeatErrors
   }
 
   // if test is marked to be failed, flip the result unless `TestSyntaxError` is present

--- a/test/e2e/test/repeats.test.ts
+++ b/test/e2e/test/repeats.test.ts
@@ -1,7 +1,7 @@
 import type { TestModule } from 'vitest/node'
 import { resolve } from 'pathe'
 import { expect, test } from 'vitest'
-import { runVitest } from '../../test-utils'
+import { runInlineTests, runVitest } from '../../test-utils'
 
 const root = resolve(__dirname, '..', 'fixtures', 'repeats')
 
@@ -23,4 +23,34 @@ test('repeats config option is exposed to tests and repeats execution', async ()
   const overridden = tests.find(t => t.name === 'test option overrides config')!
   expect(overridden.options.repeats).toBe(1)
   expect(overridden.diagnostic()!.repeatCount).toBe(1)
+})
+
+test('failed repeats are retained after a successful repeat', async () => {
+  const { errorTree, results } = await runInlineTests({
+    'repeats.test.js': `
+      import { it } from 'vitest'
+
+      it('fails twice then passes', { repeats: 2, retry: 1 }, ({ task }) => {
+        if (task.result.repeatCount < 2) {
+          throw new Error('repeat ' + task.result.repeatCount + ' failed')
+        }
+      })
+    `,
+  })
+
+  expect(errorTree()).toMatchInlineSnapshot(`
+    {
+      "repeats.test.js": {
+        "fails twice then passes": [
+          "repeat 0 failed",
+          "repeat 0 failed",
+          "repeat 1 failed",
+          "repeat 1 failed",
+        ],
+      },
+    }
+  `)
+  const [test] = results[0].children.allTests()
+  expect(test.diagnostic()!.retryCount).toBe(2)
+  expect(test.diagnostic()!.repeatCount).toBe(2)
 })

--- a/test/e2e/test/repeats.test.ts
+++ b/test/e2e/test/repeats.test.ts
@@ -54,3 +54,36 @@ test('failed repeats are retained after a successful repeat', async () => {
   expect(test.diagnostic()!.retryCount).toBe(2)
   expect(test.diagnostic()!.repeatCount).toBe(2)
 })
+
+test('onTestFailed runs only for failed repeats', async () => {
+  const { errorTree } = await runInlineTests({
+    'repeats.test.js': `
+      import { expect, it } from 'vitest'
+
+      const failedRepeats = []
+
+      it('fails first repeat', { repeats: 1 }, ({ task, onTestFailed }) => {
+        const repeatCount = task.result.repeatCount
+        onTestFailed(() => failedRepeats.push(repeatCount))
+        if (repeatCount === 0) {
+          throw new Error('repeat 0 failed')
+        }
+      })
+
+      it('records failed repeats', () => {
+        expect(failedRepeats).toEqual([0])
+      })
+    `,
+  })
+
+  expect(errorTree()).toMatchInlineSnapshot(`
+    {
+      "repeats.test.js": {
+        "fails first repeat": [
+          "repeat 0 failed",
+        ],
+        "records failed repeats": "passed",
+      },
+    }
+  `)
+})

--- a/test/unit/test/on-finished.test.ts
+++ b/test/unit/test/on-finished.test.ts
@@ -120,7 +120,6 @@ describe('repeats fail', () => {
         "(0, 1) fail",
         "(0, 2) run",
         "(0, 2) finish",
-        "(0, 2) fail",
       ]
     `)
   })

--- a/test/unit/test/repeats.test.ts
+++ b/test/unit/test/repeats.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, test, TestRunner } from 'vitest'
+import { afterAll, describe, expect, test } from 'vitest'
 
 const testNumbers: number[] = []
 
@@ -51,8 +51,46 @@ describe('testing repeats with retry', () => {
     })
   })
 
-  test('should not reset retry count', { repeats: 2, retry: 1 }, () => {
-    expect(TestRunner.getCurrentTest()!.result?.retryCount).toBe(3)
+  const runs: [repeatCount: number, retryCount: number][] = []
+
+  test('retries each repeat once', { repeats: 2, retry: 1 }, ({ task }) => {
+    const repeatCount = task.result!.repeatCount!
+    const retryCount = task.result!.retryCount!
+    runs.push([repeatCount, retryCount])
+    if (repeatCount === retryCount) {
+      throw new Error('retry')
+    }
+  })
+
+  test('keeps retry count across repeats', () => {
+    expect(runs).toMatchInlineSnapshot(`
+      [
+        [
+          0,
+          0,
+        ],
+        [
+          0,
+          1,
+        ],
+        [
+          1,
+          1,
+        ],
+        [
+          1,
+          2,
+        ],
+        [
+          2,
+          2,
+        ],
+        [
+          2,
+          3,
+        ],
+      ]
+    `)
   })
 })
 


### PR DESCRIPTION
### Description

While looking into `test.fails + retry` oddity https://github.com/vitest-dev/vitest/issues/11068, found something unusual with `repeats` too. 

The repeats loop currently reuses `result.state` between iterations. For example, this causes a successful repeat after a failure to trigger `onTestFailed`. For another example, with `retry` enabled, a later successful repeat can erase failures from earlier repeats and report the test as passed.

This PR resets the result for each repeat and collects failed repeat errors separately, so each repeat is evaluated independently and any failed repeat keeps the overall test failed.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
