### PR TITLE
fix(mocker): isolate concurrent mock call stacks (fix #7040)

### DIFF
--- a/packages/vitest/src/runtime/moduleRunner/moduleMocker.ts
+++ b/packages/vitest/src/runtime/moduleRunner/moduleMocker.ts
@@ -229,18 +229,15 @@ export class VitestMocker extends BareModuleMocker {
         && !callstack.includes(mockId)
         && !callstack.includes(url)
       ) {
+        const mockCallstack = [...callstack, mockId]
         try {
-          callstack.push(mockId)
-          // this will not work if user does Promise.all(import(), import())
-          // we can also use AsyncLocalStorage to store callstack, but this won't work in the browser
-          // maybe we should improve mock API in the future?
-          this.mockContext.callstack = callstack
+          // Keep a separate stack for this factory. Dynamic imports can run in
+          // parallel and must not be mistaken for this factory's self-import.
+          this.mockContext.callstack = mockCallstack
           return await this.callFunctionMock(mockId, this.getMockPath(url), mock)
         }
         finally {
           this.mockContext.callstack = null
-          const indexMock = callstack.indexOf(mockId)
-          callstack.splice(indexMock, 1)
         }
       }
       else if (mock.type === 'redirect' && !callstack.includes(mock.redirect)) {

--- a/test/e2e/test/mocking.test.ts
+++ b/test/e2e/test/mocking.test.ts
@@ -44,6 +44,41 @@ test('spy is not called here', () => {
   `)
 })
 
+test('concurrent dynamic imports use the manual mock', async () => {
+  const { stderr, errorTree } = await runInlineTests({
+    './target.ts': `export default 'original'`,
+    './basic.test.ts': `
+import { expect, test, vi } from 'vitest'
+
+vi.mock(import('./target.ts'), () => ({ default: 'mocked' }))
+
+test('uses the mock for every concurrent import', async () => {
+  await import('node:path')
+  const modules = await Promise.all([
+    import('./target.ts'),
+    import('./target.ts'),
+    import('./target.ts'),
+  ])
+
+  expect(modules.map(module => module.default)).toEqual([
+    'mocked',
+    'mocked',
+    'mocked',
+  ])
+})
+    `,
+  })
+
+  expect(stderr).toBe('')
+  expect(errorTree()).toMatchInlineSnapshot(`
+    {
+      "basic.test.ts": {
+        "uses the mock for every concurrent import": "passed",
+      },
+    }
+  `)
+})
+
 test('mockReset works with autospied Node modules', async () => {
   const { stderr, testTree } = await runInlineTests({
     'vitest.config.js': {


### PR DESCRIPTION
Fixes #7040.

## What changed

Manual mock evaluation no longer mutates the caller's import call stack. Each factory receives a copied stack containing its mock ID.

## Why

Concurrent dynamic imports previously shared the same mutable stack. Once one manual mock factory appended its mock ID, concurrent imports could be treated as self-imports and load the original module instead of the mock.

## Validation

- Added an E2E regression test for three concurrent imports of one manually mocked module.
- The test fails on the baseline with `['mocked', 'original', 'original']`.
- `pnpm -C test/e2e exec vitest run test/mocking.test.ts` — passed (19 tests)
- `pnpm exec eslint packages/vitest/src/runtime/moduleRunner/moduleMocker.ts test/e2e/test/mocking.test.ts` — passed
- `pnpm typecheck` — passed

## AI assistance

AI assistance was used for code investigation, implementation, and test drafting. The contributor reviewed the change and validation results.
