### PR TITLE
docs: fix typecheck exclude default in documentation

### DIFF
--- a/docs/config/typecheck.md
+++ b/docs/config/typecheck.md
@@ -47,7 +47,7 @@ Glob pattern for files that should be treated as test files.
 ## typecheck.exclude
 
 - **Type:** `string[]`
-- **Default:** `['**/node_modules/**', '**/dist/**', '**/cypress/**', '**/.{idea,git,cache,output,temp}/**']`
+- **Default:** `['**/node_modules/**', '**/.git/**']`
 
 Glob pattern for files that should not be treated as test files.
 

--- a/packages/vitest/src/node/types/config.ts
+++ b/packages/vitest/src/node/types/config.ts
@@ -1103,7 +1103,7 @@ export interface TypecheckConfig {
   /**
    * Pattern for files that should not be treated as test files
    *
-   * @default ['**\/node_modules/**', '**\/dist/**', '**\/cypress/**', '**\/.{idea,git,cache,output,temp}/**', '**\/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,eslint,prettier}.config.*']
+   * @default ['**\/node_modules/**', '**\/.git/**']
    */
   exclude: string[]
   /**


### PR DESCRIPTION
### Description

`docs/config/typecheck.md` uses older default  exclusions ,  the docs still list `dist`,`cypress` and cache directories , meanwhile `packages/vitest/src/defaults.ts` , `defaultExclude` now include : 
`**/node_modules/**` and ` **/.git/**` 
therefore changed it to current behaviour.  Didn't changed anything else.

## AI Assistance
Used codex to verify the mismatch , reviewed change and contribution myself

## Checks
One line change in document correction , verified it against the current configuration , changed that simplified them.

### Update

>I also updated the `typecheck.exclude` JSDoc default in `packages/vitest/src/node/types/config.ts`, so editor tooltips match the current `defaultExclude` value.
