### PR TITLE
fix: remove root temp directory on close (fix #11224)

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -20,6 +20,7 @@ import type { CoverageProvider, ResolvedCoverageOptions } from './types/coverage
 import type { Reporter } from './types/reporter'
 import type { TestRunResult } from './types/tests'
 import type { VCSProvider } from './vcs/vcs'
+import { rm } from 'node:fs/promises'
 import os, { tmpdir } from 'node:os'
 import { SnapshotManager } from '@vitest/snapshot/manager'
 import { deepClone, deepMerge, nanoid, noop, toArray } from '@vitest/utils/helpers'
@@ -1636,6 +1637,7 @@ export class Vitest {
           this._checkUnhandledErrors(errors)
         })
         await this._traces?.finish()
+        await rm(this._tmpDir, { force: true, recursive: true }).catch(noop)
       })()
     }
     return this.closingPromise

--- a/test/e2e/test/create-vitest.test.ts
+++ b/test/e2e/test/create-vitest.test.ts
@@ -1,4 +1,5 @@
 import type { TestModule } from 'vitest/node'
+import { existsSync } from 'node:fs'
 import { expect, it, onTestFinished, vi } from 'vitest'
 import { createVitest } from 'vitest/node'
 
@@ -14,6 +15,7 @@ it(createVitest, async () => {
     ],
   })
   onTestFinished(() => ctx.close())
+  const tmpDir = ctx._tmpDir
   const testFiles = await ctx.globTestSpecifications()
   await ctx.runTestSpecifications(testFiles, false)
 
@@ -26,4 +28,8 @@ it(createVitest, async () => {
 
   expect(errors).toHaveLength(0)
   expect(reason).toBe('passed')
+
+  expect(existsSync(tmpDir)).toBe(true)
+  await ctx.close()
+  expect(existsSync(tmpDir)).toBe(false)
 })


### PR DESCRIPTION
Prepared with Codex assistance for @jesusgraterol, who reviewed the change and this description.

## Summary

- remove the root transform directory when `Vitest.close()` completes
- cover the cleanup through the `createVitest` API

## Test

- `pnpm run build`
- `CI=true pnpm -C test/e2e test test/create-vitest.test.ts`
- `pnpm test`
- `pnpm typecheck`
- `CI=true pnpm lint`