### PR TITLE
fix(vitest): keep nextTick and queueMicrotask native when toNotFake is used

### DIFF
--- a/docs/config/faketimers.md
+++ b/docs/config/faketimers.md
@@ -32,7 +32,9 @@ Mocking `nextTick` is not supported when running Vitest inside `node:child_proce
 - **Type:** `('setTimeout' | 'clearTimeout' | 'setImmediate' | 'clearImmediate' | 'setInterval' | 'clearInterval' | 'Date' | 'nextTick' | 'hrtime' | 'requestAnimationFrame' | 'cancelAnimationFrame' | 'requestIdleCallback' | 'cancelIdleCallback' | 'performance' | 'queueMicrotask' | 'Intl' | 'Temporal')[]`
 - **Default:** `[]`
 
-An array with names of global methods and APIs to keep native. All other available timers will be mocked. For example, to keep `setInterval()` native and mock all other timers, specify this property as `['setInterval']`.
+An array with names of global methods and APIs to keep native. All other available timers will be mocked, except `nextTick` and `queueMicrotask`, which Vitest keeps native by default just as it does when neither option is set. For example, to keep `setInterval()` native and mock all other timers, specify this property as `['setInterval']`.
+
+To fake `nextTick` or `queueMicrotask`, list them in [`toFake`](#faketimers-tofake) instead.
 
 Mocking `nextTick` is not supported when running Vitest inside `node:child_process` by using `--pool=forks`. When running with `--pool=forks`, Vitest automatically adds `nextTick` to the `toNotFake` array.
 

--- a/packages/vitest/src/integrations/mock/timers.ts
+++ b/packages/vitest/src/integrations/mock/timers.ts
@@ -164,18 +164,24 @@ export class FakeTimers {
     }
 
     let toNotFake = this._userConfig?.toNotFake
-    if (toFake === undefined && toNotFake === undefined) {
-      // Do not mock timers internally used by node by default. It can still be mocked through userConfig.
+    if (toFake === undefined) {
+      // Do not mock timers internally used by node by default. They can still be mocked through
+      // `toFake`. `toNotFake` subtracts from this default set: it must not fall through to the
+      // default of @sinonjs/fake-timers, which fakes every available method.
+      const excluded = new Set<string>(['nextTick', 'queueMicrotask', ...toNotFake ?? []])
       toFake = (Object.keys(this._fakeTimers.timers) as FakeMethod[])
-        .filter(timer => timer !== 'nextTick' && timer !== 'queueMicrotask')
+        .filter(timer => !excluded.has(timer))
+      // the exclusions are already applied above, and both options cannot be passed together
+      toNotFake = undefined
     }
-    if (isChildProcess() && toNotFake && !toNotFake.includes('nextTick')) {
-      toNotFake = [...toNotFake, 'nextTick']
-    }
+
+    // `toFake` and `toNotFake` cannot be passed together, so the resolved values replace whatever
+    // the user config holds instead of being merged with it
+    const { toFake: _toFake, toNotFake: _toNotFake, ...restConfig } = this._userConfig ?? {}
 
     this._clock = this._fakeTimers.install({
       now: fakeDate,
-      ...this._userConfig,
+      ...restConfig,
       ...(toFake && { toFake }),
       ...(toNotFake && { toNotFake }),
       ignoreMissingTimers: true,

--- a/test/unit/test/fixtures/timers.suite.ts
+++ b/test/unit/test/fixtures/timers.suite.ts
@@ -154,7 +154,7 @@ describe('FakeTimers', () => {
       expect(global.clearImmediate).toBe(origClearImmediate)
     })
 
-    it.skipIf(isChildProcess)('mocks process.nextTick when toNotFake does not include nextTick', () => {
+    it('does not mock process.nextTick when toNotFake is used without it', () => {
       const origNextTick = () => {}
       const global = {
         Date: FakeDate,
@@ -164,21 +164,7 @@ describe('FakeTimers', () => {
         },
         setTimeout,
       }
-      const timers = new FakeTimers({ global, config: { toNotFake: [] } })
-      timers.useFakeTimers()
-      expect(global.process.nextTick).not.toBe(origNextTick)
-    })
-
-    it.runIf(isChildProcess)('does not mock process.nextTick when toNotFake does not include nextTick and is child_process', () => {
-      const origNextTick = () => {}
-      const global = {
-        Date: FakeDate,
-        clearTimeout,
-        process: {
-          nextTick: origNextTick,
-        },
-        setTimeout,
-      }
+      // nextTick is excluded by the Vitest default, and `toNotFake` only subtracts from it
       const timers = new FakeTimers({ global, config: { toNotFake: [] } })
       timers.useFakeTimers()
       expect(global.process.nextTick).toBe(origNextTick)
@@ -197,6 +183,38 @@ describe('FakeTimers', () => {
       const timers = new FakeTimers({ global, config: { toNotFake: ['nextTick'] } })
       timers.useFakeTimers()
       expect(global.process.nextTick).toBe(origNextTick)
+    })
+
+    it('keeps queueMicrotask native when toNotFake is used without it', () => {
+      const origQueueMicrotask = () => {}
+      const origSetImmediate = () => {}
+      const origSetTimeout = setTimeout
+      const global = {
+        Date: FakeDate,
+        clearTimeout,
+        queueMicrotask: origQueueMicrotask,
+        setImmediate: origSetImmediate,
+        setTimeout,
+      }
+      // `toNotFake` subtracts from the Vitest default, it does not fall back to faking everything
+      const timers = new FakeTimers({ global, config: { toNotFake: ['setImmediate'] } })
+      timers.useFakeTimers()
+      expect(global.setTimeout).not.toBe(origSetTimeout)
+      expect(global.setImmediate).toBe(origSetImmediate)
+      expect(global.queueMicrotask).toBe(origQueueMicrotask)
+    })
+
+    it('mocks queueMicrotask when toFake includes it', () => {
+      const origQueueMicrotask = () => {}
+      const global = {
+        Date: FakeDate,
+        clearTimeout,
+        queueMicrotask: origQueueMicrotask,
+        setTimeout,
+      }
+      const timers = new FakeTimers({ global, config: { toFake: ['queueMicrotask'] } })
+      timers.useFakeTimers()
+      expect(global.queueMicrotask).not.toBe(origQueueMicrotask)
     })
 
     it("toFake and toNotFake cannot be used together", () => {


### PR DESCRIPTION
### Description

Closes #11226.

`FakeTimers.useFakeTimers()` only computed Vitest's own default exclusion set when **both** `toFake` and `toNotFake` were unset:

```js
if (toFake === undefined && toNotFake === undefined) {
  toFake = Object.keys(this._fakeTimers.timers)
    .filter(timer => timer !== 'nextTick' && timer !== 'queueMicrotask')
}
```

So naming `toNotFake` skipped the default entirely and fell through to the `@sinonjs/fake-timers` default, which fakes every available method. `{ toNotFake: ['Temporal'] }` did not subtract one API from Vitest's set — it replaced that set with sinon's and switched **on** `queueMicrotask` faking, which hangs promise-driven code.

That is easy to hit because the v5 migration guide recommends exactly this pattern for keeping `Temporal` native. `nextTick` escaped only incidentally, through the separate `isChildProcess()` guard that re-added it.

Per @hi-ogawa's comment on the issue, the fix forces both `nextTick` and `queueMicrotask` to stay native when `toNotFake` is used.

### Changes

`packages/vitest/src/integrations/mock/timers.ts` — the default is now computed whenever `toFake` is unset, with `toNotFake` folded into the exclusion set:

```ts
if (toFake === undefined) {
  const excluded = new Set(['nextTick', 'queueMicrotask', ...toNotFake ?? []])
  toFake = Object.keys(this._fakeTimers.timers).filter(t => !excluded.has(t))
  toNotFake = undefined
}
```

`toNotFake` is cleared because the exclusions are already expressed in `toFake`, and sinon rejects both options together. For the same reason the install config now spreads `restConfig` (the user config minus both keys) rather than the whole user config, so the resolved values replace the user's instead of being overwritten by them.

The `isChildProcess()` block that appended `nextTick` to `toNotFake` is dropped: the default set already excludes `nextTick` on every path that reaches it, and the explicit `toFake` request still throws `process.nextTick cannot be mocked inside child_process`.

`toFake` behaviour is unchanged — it is still an exact list, so `toFake: ['queueMicrotask']` fakes it.

### Tests

`test/unit/test/fixtures/timers.suite.ts`:

- new: `toNotFake: ['setImmediate']` keeps `setImmediate` **and** `queueMicrotask` native while still faking `setTimeout` — the regression from the issue.
- new: `toFake: ['queueMicrotask']` still fakes it, so the opt-in is not lost.
- updated: `mocks process.nextTick when toNotFake does not include nextTick` asserted the old behaviour (`toNotFake: []` faking `nextTick`) and is now `does not mock process.nextTick when toNotFake is used without it`. It no longer needs `skipIf(isChildProcess)`, which also makes the `runIf(isChildProcess)` twin redundant — the two are merged into one test that holds on every pool.

`pnpm vitest run test/timers-node.test.ts test/timers-jsdom.test.ts` from `test/unit`: **446 passed, 28 skipped**, across forks / threads / vmThreads in both environments.

The full `test/unit` suite shows 42 failures, but the same 42 fail on a clean `main` at 7f75f90 (`27 failed | 622 passed` in both runs) — none are related to this change.

`docs/config/faketimers.md` is updated to state that `toNotFake` subtracts from Vitest's default and that `nextTick` / `queueMicrotask` stay native unless listed in `toFake`.
