### PR TITLE
feat: expose per-retry/repeat attempt result

### DIFF
--- a/packages/vitest/src/node/reporters/reported-tasks.ts
+++ b/packages/vitest/src/node/reporters/reported-tasks.ts
@@ -199,8 +199,6 @@ export class TestCase extends ReportedTaskImplementation {
   }
 
   /**
-   * @experimental
-   *
    * Individual results for every retry and repeat attempt.
    */
   public attempts(): ReadonlyArray<TestAttempt> {
@@ -641,7 +639,6 @@ export type TestState = TestResult['state']
 
 /**
  * The result of an individual test attempt.
- * @experimental
  */
 export interface TestAttempt {
   /** The state after applying the test's expected failure option. */

--- a/packages/vitest/src/node/reporters/reported-tasks.ts
+++ b/packages/vitest/src/node/reporters/reported-tasks.ts
@@ -199,6 +199,26 @@ export class TestCase extends ReportedTaskImplementation {
   }
 
   /**
+   * @experimental
+   *
+   * Individual results for every retry and repeat attempt.
+   */
+  public attempts(): ReadonlyArray<TestAttempt> {
+    return (this.task.result?.attempts || []).map(attempt => ({
+      state: attempt.state === 'pass'
+        ? 'passed'
+        : attempt.state === 'fail'
+          ? 'failed'
+          : 'skipped',
+      errors: attempt.errors as TestError[] | undefined,
+      duration: attempt.duration,
+      startTime: attempt.startTime,
+      retryCount: attempt.retryCount,
+      repeatCount: attempt.repeatCount,
+    }))
+  }
+
+  /**
    * Test annotations added via the `task.annotate` API during the test execution.
    */
   public annotations(): ReadonlyArray<TestAnnotation> {
@@ -618,6 +638,25 @@ function buildOptions(
 export type TestSuiteState = 'skipped' | 'pending' | 'failed' | 'passed'
 export type TestModuleState = TestSuiteState | 'queued'
 export type TestState = TestResult['state']
+
+/**
+ * The result of an individual test attempt.
+ * @experimental
+ */
+export interface TestAttempt {
+  /** The state after applying the test's expected failure option. */
+  readonly state: 'passed' | 'failed' | 'skipped'
+  /** Errors produced by this attempt. */
+  readonly errors: ReadonlyArray<TestError> | undefined
+  /** How long in milliseconds the attempt took to run. */
+  readonly duration: number
+  /** Time in milliseconds when the attempt started running. */
+  readonly startTime: number
+  /** The total number of retries before this attempt. */
+  readonly retryCount: number
+  /** The zero-based repeat index of this attempt. */
+  readonly repeatCount: number
+}
 
 export type TestResult
   = | TestResultPassed

--- a/packages/vitest/src/node/reporters/reported-tasks.ts
+++ b/packages/vitest/src/node/reporters/reported-tasks.ts
@@ -213,8 +213,8 @@ export class TestCase extends ReportedTaskImplementation {
       errors: attempt.errors as TestError[] | undefined,
       duration: attempt.duration,
       startTime: attempt.startTime,
-      retryCount: attempt.retryCount,
-      repeatCount: attempt.repeatCount,
+      retryIndex: attempt.retryIndex,
+      repeatIndex: attempt.repeatIndex,
     }))
   }
 
@@ -652,10 +652,10 @@ export interface TestAttempt {
   readonly duration: number
   /** Time in milliseconds when the attempt started running. */
   readonly startTime: number
-  /** The total number of retries before this attempt. */
-  readonly retryCount: number
-  /** The zero-based repeat index of this attempt. */
-  readonly repeatCount: number
+  /** The zero-based retry index within the repeat. */
+  readonly retryIndex: number
+  /** The zero-based repeat index. */
+  readonly repeatIndex: number
 }
 
 export type TestResult

--- a/packages/vitest/src/public/index.ts
+++ b/packages/vitest/src/public/index.ts
@@ -92,6 +92,7 @@ export type {
   TaskBase as RunnerTaskBase,
   TaskEventPack as RunnerTaskEventPack,
   TaskResult as RunnerTaskResult,
+  TaskResultAttempt as RunnerTaskResultAttempt,
   TaskResultPack as RunnerTaskResultPack,
   Test as RunnerTestCase,
   File as RunnerTestFile,

--- a/packages/vitest/src/public/node.ts
+++ b/packages/vitest/src/public/node.ts
@@ -77,6 +77,7 @@ export type {
   ModuleDiagnostic,
   TaskOptions,
 
+  TestAttempt,
   TestCase,
   TestCollection,
   TestDiagnostic,

--- a/packages/vitest/src/runtime/runner/run.ts
+++ b/packages/vitest/src/runtime/runner/run.ts
@@ -634,8 +634,8 @@ async function runTest(test: Test, runner: VitestRunner): Promise<void> {
           errors: errors?.length ? errors : undefined,
           duration: now() - attemptStart,
           startTime: attemptStartTime,
-          retryCount: test.result!.retryCount ?? 0,
-          repeatCount: test.result!.repeatCount ?? 0,
+          retryIndex: retryCount,
+          repeatIndex: repeatCount,
         })
       }
       let beforeEachCleanups: unknown[] = []

--- a/packages/vitest/src/runtime/runner/run.ts
+++ b/packages/vitest/src/runtime/runner/run.ts
@@ -12,6 +12,7 @@ import type {
   Task,
   TaskMeta,
   TaskResult,
+  TaskResultAttempt,
   TaskResultPack,
   TaskState,
   TaskUpdateEvent,
@@ -616,13 +617,27 @@ async function runTest(test: Test, runner: VitestRunner): Promise<void> {
   const $ = runner.trace!
 
   const repeats = test.repeats ?? 0
+  const attempts: TaskResultAttempt[] = []
   let hasFailedRepeat = false
   for (let repeatCount = 0; repeatCount <= repeats; repeatCount++) {
     // Force widening to TaskState because TypeScript cannot track mutations made by hooks and the test.
     test.result.state = 'run' as TaskState
     const retry = getRetryCount(test.retry)
     for (let retryCount = 0; retryCount <= retry; retryCount++) {
+      const attemptStart = now()
+      const attemptStartTime = unixNow()
       const attemptErrorsStart = test.result.errors?.length ?? 0
+      const recordAttempt = (state: TaskResultAttempt['state']) => {
+        const errors = test.result!.errors?.slice(attemptErrorsStart)
+        attempts.push({
+          state,
+          errors: errors?.length ? errors : undefined,
+          duration: now() - attemptStart,
+          startTime: attemptStartTime,
+          retryCount: test.result!.retryCount ?? 0,
+          repeatCount: test.result!.repeatCount ?? 0,
+        })
+      }
       let beforeEachCleanups: unknown[] = []
       // fixtureCheckpoint is passed by callAroundEachHooks - it represents the count
       // of fixture cleanup functions AFTER all aroundEach fixtures have been resolved
@@ -729,12 +744,14 @@ async function runTest(test: Test, runner: VitestRunner): Promise<void> {
 
       // skipped with new PendingError
       if (test.result?.pending || test.result?.state === 'skip') {
+        recordAttempt('skip')
         test.mode = 'skip'
         test.result = {
           state: 'skip',
           note: test.result?.note,
           pending: true,
           duration: now() - start,
+          attempts,
         }
         updateTask('test-finished', test, runner)
         setCurrentTest(undefined)
@@ -758,6 +775,7 @@ async function runTest(test: Test, runner: VitestRunner): Promise<void> {
           }
         }
       }
+      recordAttempt(test.result.state === 'pass' ? 'pass' : 'fail')
       if (test.result.state === 'pass') {
         break
       }
@@ -790,6 +808,7 @@ async function runTest(test: Test, runner: VitestRunner): Promise<void> {
   if (hasFailedRepeat) {
     test.result.state = 'fail'
   }
+  test.result.attempts = attempts
 
   cleanupRunningTest()
   setCurrentTest(undefined)

--- a/packages/vitest/src/runtime/runner/types.ts
+++ b/packages/vitest/src/runtime/runner/types.ts
@@ -159,6 +159,25 @@ export interface TaskMeta {
 }
 
 /**
+ * The result of an individual test attempt.
+ * @experimental
+ */
+export interface TaskResultAttempt {
+  /** The state after applying the test's expected failure option. */
+  state: 'pass' | 'fail' | 'skip'
+  /** Errors produced by this attempt. */
+  errors?: TestError[]
+  /** How long in milliseconds the attempt took to run. */
+  duration: number
+  /** Time in milliseconds when the attempt started running. */
+  startTime: number
+  /** The total number of retries before this attempt. */
+  retryCount: number
+  /** The zero-based repeat index of this attempt. */
+  repeatCount: number
+}
+
+/**
  * The result of calling a task.
  */
 export interface TaskResult {
@@ -174,6 +193,11 @@ export interface TaskResult {
    * if `expect.soft()` failed multiple times or `retry` was triggered.
    */
   errors?: TestError[]
+  /**
+   * Individual results for every retry and repeat attempt.
+   * @experimental
+   */
+  attempts?: TaskResultAttempt[]
   /**
    * How long in milliseconds the task took to run.
    */

--- a/packages/vitest/src/runtime/runner/types.ts
+++ b/packages/vitest/src/runtime/runner/types.ts
@@ -171,10 +171,10 @@ export interface TaskResultAttempt {
   duration: number
   /** Time in milliseconds when the attempt started running. */
   startTime: number
-  /** The total number of retries before this attempt. */
-  retryCount: number
-  /** The zero-based repeat index of this attempt. */
-  repeatCount: number
+  /** The zero-based retry index within the repeat. */
+  retryIndex: number
+  /** The zero-based repeat index. */
+  repeatIndex: number
 }
 
 /**

--- a/packages/vitest/src/runtime/runner/types.ts
+++ b/packages/vitest/src/runtime/runner/types.ts
@@ -160,7 +160,6 @@ export interface TaskMeta {
 
 /**
  * The result of an individual test attempt.
- * @experimental
  */
 export interface TaskResultAttempt {
   /** The state after applying the test's expected failure option. */
@@ -195,7 +194,6 @@ export interface TaskResult {
   errors?: TestError[]
   /**
    * Individual results for every retry and repeat attempt.
-   * @experimental
    */
   attempts?: TaskResultAttempt[]
   /**

--- a/test/e2e/test/reported-tasks.test.ts
+++ b/test/e2e/test/reported-tasks.test.ts
@@ -276,6 +276,37 @@ it('correctly reports flaky tests', ({ testModule }) => {
   const result = testFlaky.result()!
   expect(result.state).toBe('passed')
   expect(result.errors).toHaveLength(2)
+  expect(testFlaky.attempts().map(attempt => ({
+    state: attempt.state,
+    errors: attempt.errors?.map(error => error.message),
+    retryCount: attempt.retryCount,
+    repeatCount: attempt.repeatCount,
+  }))).toMatchInlineSnapshot(`
+    [
+      {
+        "errors": [
+          "expected +0 to be 2 // Object.is equality",
+        ],
+        "repeatCount": 0,
+        "retryCount": 0,
+        "state": "failed",
+      },
+      {
+        "errors": [
+          "expected 1 to be 2 // Object.is equality",
+        ],
+        "repeatCount": 0,
+        "retryCount": 1,
+        "state": "failed",
+      },
+      {
+        "errors": undefined,
+        "repeatCount": 0,
+        "retryCount": 2,
+        "state": "passed",
+      },
+    ]
+  `)
 })
 
 it('correctly reports repeated tests', ({ testModule }) => {

--- a/test/e2e/test/reported-tasks.test.ts
+++ b/test/e2e/test/reported-tasks.test.ts
@@ -279,30 +279,30 @@ it('correctly reports flaky tests', ({ testModule }) => {
   expect(testFlaky.attempts().map(attempt => ({
     state: attempt.state,
     errors: attempt.errors?.map(error => error.message),
-    retryCount: attempt.retryCount,
-    repeatCount: attempt.repeatCount,
+    retryIndex: attempt.retryIndex,
+    repeatIndex: attempt.repeatIndex,
   }))).toMatchInlineSnapshot(`
     [
       {
         "errors": [
           "expected +0 to be 2 // Object.is equality",
         ],
-        "repeatCount": 0,
-        "retryCount": 0,
+        "repeatIndex": 0,
+        "retryIndex": 0,
         "state": "failed",
       },
       {
         "errors": [
           "expected 1 to be 2 // Object.is equality",
         ],
-        "repeatCount": 0,
-        "retryCount": 1,
+        "repeatIndex": 0,
+        "retryIndex": 1,
         "state": "failed",
       },
       {
         "errors": undefined,
-        "repeatCount": 0,
-        "retryCount": 2,
+        "repeatIndex": 0,
+        "retryIndex": 2,
         "state": "passed",
       },
     ]

--- a/test/e2e/test/retry.test.ts
+++ b/test/e2e/test/retry.test.ts
@@ -163,50 +163,50 @@ test('expected failures can recover through a retry in every repeat', async () =
   expect(attempts.map(attempt => ({
     state: attempt.state,
     errors: attempt.errors?.map(error => error.message) || [],
-    retryCount: attempt.retryCount,
-    repeatCount: attempt.repeatCount,
+    retryIndex: attempt.retryIndex,
+    repeatIndex: attempt.repeatIndex,
   }))).toMatchInlineSnapshot(`
     [
       {
         "errors": [
           "Expect test to fail",
         ],
-        "repeatCount": 0,
-        "retryCount": 0,
+        "repeatIndex": 0,
+        "retryIndex": 0,
         "state": "failed",
       },
       {
         "errors": [],
-        "repeatCount": 0,
-        "retryCount": 1,
+        "repeatIndex": 0,
+        "retryIndex": 1,
         "state": "passed",
       },
       {
         "errors": [
           "Expect test to fail",
         ],
-        "repeatCount": 1,
-        "retryCount": 1,
+        "repeatIndex": 1,
+        "retryIndex": 0,
         "state": "failed",
       },
       {
         "errors": [],
-        "repeatCount": 1,
-        "retryCount": 2,
+        "repeatIndex": 1,
+        "retryIndex": 1,
         "state": "passed",
       },
       {
         "errors": [
           "Expect test to fail",
         ],
-        "repeatCount": 2,
-        "retryCount": 2,
+        "repeatIndex": 2,
+        "retryIndex": 0,
         "state": "failed",
       },
       {
         "errors": [],
-        "repeatCount": 2,
-        "retryCount": 3,
+        "repeatIndex": 2,
+        "retryIndex": 1,
         "state": "passed",
       },
     ]

--- a/test/e2e/test/retry.test.ts
+++ b/test/e2e/test/retry.test.ts
@@ -131,7 +131,7 @@ test('expected failures exhaust retries in every repeat when assertions pass', a
 })
 
 test('expected failures can recover through a retry in every repeat', async () => {
-  const { stderr, errorTree } = await runInlineTests({
+  const { stderr, errorTree, results } = await runInlineTests({
     'repeats.test.js': `
       import { afterAll, expect, it } from 'vitest'
 
@@ -157,6 +157,64 @@ test('expected failures can recover through a retry in every repeat', async () =
       },
     }
   `)
+
+  const [test] = results[0].children.allTests()
+  const attempts = test.attempts()
+  expect(attempts.map(attempt => ({
+    state: attempt.state,
+    errors: attempt.errors?.map(error => error.message) || [],
+    retryCount: attempt.retryCount,
+    repeatCount: attempt.repeatCount,
+  }))).toMatchInlineSnapshot(`
+    [
+      {
+        "errors": [
+          "Expect test to fail",
+        ],
+        "repeatCount": 0,
+        "retryCount": 0,
+        "state": "failed",
+      },
+      {
+        "errors": [],
+        "repeatCount": 0,
+        "retryCount": 1,
+        "state": "passed",
+      },
+      {
+        "errors": [
+          "Expect test to fail",
+        ],
+        "repeatCount": 1,
+        "retryCount": 1,
+        "state": "failed",
+      },
+      {
+        "errors": [],
+        "repeatCount": 1,
+        "retryCount": 2,
+        "state": "passed",
+      },
+      {
+        "errors": [
+          "Expect test to fail",
+        ],
+        "repeatCount": 2,
+        "retryCount": 2,
+        "state": "failed",
+      },
+      {
+        "errors": [],
+        "repeatCount": 2,
+        "retryCount": 3,
+        "state": "passed",
+      },
+    ]
+  `)
+  attempts.forEach((attempt) => {
+    expect(attempt.duration).toBeGreaterThanOrEqual(0)
+    expect(attempt.startTime).toBeGreaterThan(0)
+  })
 })
 
 test('syntax errors remain failures after successful repeats', async () => {


### PR DESCRIPTION
### Description

- closes https://github.com/vitest-dev/vitest/issues/10303
- stacked on https://github.com/vitest-dev/vitest/pull/11219

This adds an `TestCase.attempts()` API so reporters can inspect the normalized result, errors, timing, retry count, and repeat index of each test attempt. 

TODO
- [ ] doc
