### PR TITLE
fix: keep queueMicrotask native with toNotFake (fix #11226)

### DIFF
--- a/docs/config/faketimers.md
+++ b/docs/config/faketimers.md
@@ -34,6 +34,8 @@ Mocking `nextTick` is not supported when running Vitest inside `node:child_proce
 
 An array with names of global methods and APIs to keep native. All other available timers will be mocked. For example, to keep `setInterval()` native and mock all other timers, specify this property as `['setInterval']`.
 
+When `toFake` is not specified, `queueMicrotask` is also kept native by default. To mock it, specify `toFake` explicitly.
+
 Mocking `nextTick` is not supported when running Vitest inside `node:child_process` by using `--pool=forks`. When running with `--pool=forks`, Vitest automatically adds `nextTick` to the `toNotFake` array.
 
 ::: warning

--- a/packages/vitest/src/integrations/mock/timers.ts
+++ b/packages/vitest/src/integrations/mock/timers.ts
@@ -164,6 +164,15 @@ export class FakeTimers {
     }
 
     let toNotFake = this._userConfig?.toNotFake
+    if (
+      toFake === undefined
+      && toNotFake !== undefined
+      && !toNotFake.includes('queueMicrotask')
+    ) {
+      // Do not mock queueMicrotask internally used by node by default.
+      // It can still be mocked through toFake.
+      toNotFake = [...toNotFake, 'queueMicrotask']
+    }
     if (toFake === undefined && toNotFake === undefined) {
       // Do not mock timers internally used by node by default. It can still be mocked through userConfig.
       toFake = (Object.keys(this._fakeTimers.timers) as FakeMethod[])

--- a/test/unit/test/timers-queueMicrotask.test.ts
+++ b/test/unit/test/timers-queueMicrotask.test.ts
@@ -12,6 +12,16 @@ test(`node fetch works with fake timers`, async () => {
   expect(await Response.json('ok').json()).toBe('ok')
 })
 
+test(`toNotFake keeps queueMicrotask native`, async () => {
+  const nativeQueueMicrotask = queueMicrotask
+  vi.useFakeTimers({ toNotFake: ['Temporal'] })
+  onTestFinished(() => {
+    vi.useRealTimers()
+  })
+  expect(queueMicrotask).toBe(nativeQueueMicrotask)
+  expect(await Response.json('ok').json()).toBe('ok')
+})
+
 // skipped since this might cause a weird OOM on CI
 test.skip(`node fetch timeouts with fake queueMicrotask`, async () => {
   vi.useFakeTimers({ toFake: ['queueMicrotask'] })


### PR DESCRIPTION
### Description

<!-- AI assistance disclosure: this PR was prepared with assistance from OpenAI Codex. -->

Resolves #11226

When `vi.useFakeTimers` receives `toNotFake` without `toFake`, the current implementation leaves `toFake` undefined and lets `@sinonjs/fake-timers` apply its defaults. That default includes `queueMicrotask`, so `queueMicrotask` is mocked even though Vitest documents it as native by default.

This change adds `queueMicrotask` to `toNotFake` in that configuration while preserving explicit `toFake` behavior. It also adds a regression test covering native identity and Node `Response.json()`.

### Tests

- `pnpm --filter @vitest/test-unit exec vitest --project threads test/timers-queueMicrotask.test.ts`
- `pnpm --filter @vitest/test-unit exec vitest --project forks test/timers-queueMicrotask.test.ts`
- `pnpm --filter @vitest/test-unit exec vitest --project vmThreads test/timers-queueMicrotask.test.ts test/timers-node.test.ts`
- `pnpm run docs`
- `pnpm --filter @vitest/test-unit test:threads` (all relevant tests pass; the pre-existing `test/esnext-decorator.test.ts` fixture still fails with `SyntaxError: Invalid or unexpected token`)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. The PR name uses the `fix:` prefix and explains the change.
