### PR TITLE
test(ui): don't click explorer rows by coordinates in the suite report test

### DIFF
--- a/test/ui/test/helper.ts
+++ b/test/ui/test/helper.ts
@@ -69,9 +69,22 @@ export function getExplorerItem(page: Page, name: string) {
   return page.locator('[data-testid="explorer-item"]:visible').and(page.getByLabel(name, { exact: true }))
 }
 
+// The explorer renders its items in a `RecycleScroller`, so rows move while a
+// target is scrolled into view. A coordinate click (`locator.click()`) is
+// verified against the element under the cursor and then dispatched, and the
+// list can recycle in between - the click then lands on a neighbouring row.
+// Dispatching the event on the located element instead cannot hit another row.
 export async function openExplorerItem(page: Page, name: string) {
-  await getExplorerItem(page, name).scrollIntoViewIfNeeded()
-  await getExplorerItem(page, name).dispatchEvent('click')
+  const item = getExplorerItem(page, name)
+  await item.scrollIntoViewIfNeeded()
+  await item.dispatchEvent('click')
+}
+
+export async function toggleExplorerItem(page: Page, name: string, action: 'expand' | 'collapse') {
+  const label = `${action === 'expand' ? 'Expand' : 'Collapse'} ${name}`
+  const button = getExplorerItem(page, name).getByRole('button', { name: label, exact: true })
+  await button.scrollIntoViewIfNeeded()
+  await button.dispatchEvent('click')
 }
 
 export async function openExplorerFileItem(page: Page, name: string) {

--- a/test/ui/test/ui.spec.ts
+++ b/test/ui/test/ui.spec.ts
@@ -5,7 +5,7 @@ import { existsSync } from 'node:fs'
 import { expect, test } from '@playwright/test'
 import { join } from 'pathe'
 import { resolveApiToken } from '../../../packages/vitest/src/node/config/apiToken'
-import { assertDownloadAttachment, assertImageAttachment, assertTestCounts, getExplorerItem, openExplorerFileItem, openExplorerItem, startHtmlReportPreview, startVitestUi } from './helper'
+import { assertDownloadAttachment, assertImageAttachment, assertTestCounts, getExplorerItem, openExplorerFileItem, openExplorerItem, startHtmlReportPreview, startVitestUi, toggleExplorerItem } from './helper'
 
 const TEST_COUNTS = {
   pass: 21,
@@ -501,25 +501,24 @@ async function testError(page: Page) {
 async function testSuiteReport(page: Page) {
   const report = page.getByTestId('report')
 
-  await getExplorerItem(page, 'suite-report.test.ts').click()
+  await openExplorerItem(page, 'suite-report.test.ts')
   await expect(report).toContainText('before-all-marker')
   await expect(report).toContainText('direct-child-marker')
   await expect(report).toContainText('nested-child-marker')
 
-  const successfulSuite = getExplorerItem(page, 'successful suite')
-  await successfulSuite.click()
+  await openExplorerItem(page, 'successful suite')
   await expect(page.getByTestId('report')).toContainText('All tests passed in this suite')
 
-  await getExplorerItem(page, 'hook failure suite').click()
+  await openExplorerItem(page, 'hook failure suite')
   await expect(report).toContainText('before-all-marker')
   await expect(report).not.toContainText('direct-child-marker')
 
-  await getExplorerItem(page, 'child failure suite').click()
+  await openExplorerItem(page, 'child failure suite')
   await expect(report).toContainText('failing child')
   await expect(report).toContainText('direct-child-marker')
   await expect(report).not.toContainText('before-all-marker')
 
-  await getExplorerItem(page, 'nested failure suite').click()
+  await openExplorerItem(page, 'nested failure suite')
   await expect(report).toContainText('failing nested suite')
   await expect(report).toContainText('failing nested child')
   await expect(report).toContainText('nested-child-marker')
@@ -527,9 +526,9 @@ async function testSuiteReport(page: Page) {
 
   // test that the suite can be collapsed and expanded
   await expect(getExplorerItem(page, 'successful child')).toBeVisible()
-  await successfulSuite.getByRole('button', { name: 'Collapse successful suite', exact: true }).click()
+  await toggleExplorerItem(page, 'successful suite', 'collapse')
   await expect(getExplorerItem(page, 'successful child')).not.toBeVisible()
-  await successfulSuite.getByRole('button', { name: 'Expand successful suite', exact: true }).click()
+  await toggleExplorerItem(page, 'successful suite', 'expand')
   await expect(getExplorerItem(page, 'successful child')).toBeVisible()
 }
 


### PR DESCRIPTION
### Description

`ui.spec.ts > suite report navigation` is flaky. On `windows-latest` it failed in [run 34358157064](https://github.com/vitest-dev/vitest/actions/runs/34358157064/job/102488118436), and each retry failed at a *different* step: the report pane kept the previous suite after a row click, then an "Expand" click did nothing, then a "Collapse" click did nothing.

**Root cause.** The explorer renders its rows in a `RecycleScroller` (`packages/ui/client/components/explorer/Explorer.vue:264`). The `child failure suite` / `nested failure suite` rows sit at or just below the bottom of the test viewport, so `locator.click()` first has to scroll them into view. Playwright verifies the element under the cursor and *then* dispatches a real mouse event at those coordinates - and the virtual list recycles rows in between, so the click is delivered to whichever row moved into those coordinates.

I instrumented a capture-phase `click` listener and looped the interactions from the test (viewport from the Playwright config, 800x1300):

```
PROBE-FAIL round 1 "child failure suite": clicks=[{"row":"successful suite","tag":"SPAN","cls":""}] report=" All tests passed in this suite"
PROBE-FAIL round 3: expand had no effect, clicks=[{"row":"successful suite","button":"Collapse successful suite"}] (child not visible)
```

The first line is the CI failure verbatim: the click aimed at `child failure suite` was received by `successful suite`, so the report stayed on the previous suite (`Expected substring: "failing child"` / `Received string: " All tests passed in this suite"`). The second line shows the same thing happening to the expand/collapse buttons - the click meant for `Expand successful suite` hit the `Collapse successful suite` button that was rendered before the state flipped, because the whole row moved.

### Fix

- Selecting an item now uses the existing `openExplorerItem()` helper (scroll into view, then dispatch the click **on the located element**), which the trace tests already use. I added a comment there explaining that dispatching is deliberate, since `locator.click()` looks like the obvious choice.
- Toggling gets the equivalent `toggleExplorerItem(page, name, 'expand' | 'collapse')`.

Neither can be redirected to a neighbouring row, because no coordinates are involved.

### Verification

This test is intermittent rather than reliably broken, so the probe above is the actual evidence; these numbers only confirm it is reproducible. `--workers=1 --retries=0`, both the `ui` and the `html report` variant of `suite report navigation`:

| version | command | result |
| --- | --- | --- |
| `main` | `--repeat-each=25` | 3 failed / 50 runs |
| `main` | `--repeat-each=60` | 1 failed / 120 runs |
| `main` | `--repeat-each=30` | 0 failed / 60 runs (clean sample) |
| this branch | `--repeat-each=30` | 0 failed / 60 runs |

### Scope

I left the other `getExplorerItem(...).click()` call sites alone (`testError`, `testVisualRegression`, `add`, `watch-updates.spec.ts`). They use the same pattern and are probably worth converting too, but this PR only changes the test whose failure I could reproduce and verify - happy to extend it if you prefer.