### PR TITLE
fix(runner): don't cache failed fixture setups (fix #11237)

### DIFF
--- a/packages/vitest/src/runtime/runner/fixture.ts
+++ b/packages/vitest/src/runtime/runner/fixture.ts
@@ -396,12 +396,17 @@ export function withFixtures(fn: Function, options?: WithFixturesOptions) {
         }
         cachedFixtures.add(fixture)
 
-        const resolvedValue = await resolveTestFixtureValue(
-          fixture,
-          context,
-          cleanupFnArray,
-        )
-        context[fixture.name] = resolvedValue
+        try {
+          context[fixture.name] = await resolveTestFixtureValue(
+            fixture,
+            context,
+            cleanupFnArray,
+          )
+        }
+        catch (error) {
+          cachedFixtures.delete(fixture)
+          throw error
+        }
 
         cleanupFnArray.push(() => {
           cachedFixtures.delete(fixture)
@@ -489,8 +494,9 @@ async function resolveScopeFixtureValue(
     cleanupFnFileArray,
   ).then((value) => {
     fixtureContext[fixture.name] = value
-    scopedFixturePromiseCache.delete(fixture)
     return value
+  }).finally(() => {
+    scopedFixturePromiseCache.delete(fixture)
   })
   scopedFixturePromiseCache.set(fixture, promise)
   return promise

--- a/test/e2e/test/fixture-failed-setup.test.ts
+++ b/test/e2e/test/fixture-failed-setup.test.ts
@@ -1,0 +1,113 @@
+import { expect, test } from 'vitest'
+import { runInlineTests } from '../../test-utils'
+
+test('file fixture whose setup failed is set up again on retry', async () => {
+  const { stdout, errorTree } = await runInlineTests({
+    'basic.test.ts': `
+      import { expect, test } from 'vitest'
+
+      let attempts = 0
+
+      const extended = test.extend<{ file: string }>({
+        file: [
+          async ({}, use) => {
+            attempts++
+            console.log('>> init file', attempts)
+            if (attempts === 1) {
+              throw new Error('setup failed once')
+            }
+            await use('file')
+          },
+          { scope: 'file' },
+        ],
+      })
+
+      extended('test1', { retry: 1 }, ({ file }) => {
+        expect(file).toBe('file')
+      })
+    `,
+  })
+
+  expect(getFixtureLogs(stdout)).toMatchInlineSnapshot(`
+    ">> init file 1
+    >> init file 2"
+  `)
+  expect(errorTree()).toMatchInlineSnapshot(`
+    {
+      "basic.test.ts": {
+        "test1": "passed",
+      },
+    }
+  `)
+})
+
+test('worker fixture whose setup failed does not poison the next file', async () => {
+  const { stdout, errorTree } = await runInlineTests({
+    'fixture.ts': `
+      import { test } from 'vitest'
+
+      let attempts = 0
+
+      export const extended = test.extend<{ worker: string }>({
+        worker: [
+          async ({}, use) => {
+            attempts++
+            console.log('>> init worker', attempts)
+            if (attempts === 1) {
+              throw new Error('setup failed once')
+            }
+            await use('worker')
+          },
+          { scope: 'worker' },
+        ],
+      })
+    `,
+    '1-basic.test.ts': `
+      import { extended } from './fixture'
+      extended('test1', ({ worker: _worker }) => {})
+    `,
+    '2-basic.test.ts': `
+      import { extended } from './fixture'
+      extended('test1', ({ worker: _worker }) => {})
+    `,
+  }, {
+    isolate: false,
+    maxWorkers: 1,
+    pool: 'threads',
+    sequence: { sequencer: StableTestFileOrderSorter },
+  })
+
+  expect(getFixtureLogs(stdout)).toMatchInlineSnapshot(`
+    ">> init worker 1
+    >> init worker 2"
+  `)
+  expect(errorTree()).toMatchInlineSnapshot(`
+    {
+      "1-basic.test.ts": {
+        "test1": [
+          "setup failed once",
+        ],
+      },
+      "2-basic.test.ts": {
+        "test1": "passed",
+      },
+    }
+  `)
+})
+
+function getFixtureLogs(stdout: string) {
+  return stdout
+    .split('\n')
+    .filter(line => line.startsWith('>> init'))
+    .join('\n')
+}
+
+class StableTestFileOrderSorter {
+  sort(files: { moduleId: string }[]) {
+    return files.sort((a, b) => a.moduleId.localeCompare(b.moduleId))
+  }
+
+  shard(files: { moduleId: string }[]) {
+    return files
+  }
+}

--- a/test/unit/test/fixture-retry.test.ts
+++ b/test/unit/test/fixture-retry.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from 'vitest'
+
+let attempts = 0
+
+const flaky = test.extend<{ value: string }>({
+  value: async ({}, use) => {
+    attempts++
+    if (attempts === 1) {
+      throw new Error('setup failed once')
+    }
+    await use('ready')
+  },
+})
+
+flaky('fixture setup runs again on retry', { retry: 1 }, ({ value }) => {
+  expect(attempts).toBe(2)
+  expect(value).toBe('ready')
+})


### PR DESCRIPTION
### Description

Resolves #11237

A fixture whose setup throws stays marked as resolved, so setup never runs again.

Test scope: the mark in `cachedFixtures` is now removed when setup throws, so `retry` re-runs it. File and worker scope: the cached promise is now deleted in a `.finally` instead of a `.then`, so a rejection is not handed to the next test or the next file.

No change on the success path.

### Tests

A unit test for retry, and an e2e file with a file-scoped fixture that recovers on retry and a worker-scoped one that no longer poisons the next file. All three fail on main. The e2e cases are in a new file because `scoped-fixtures.test.ts` skips under rolldown. Existing fixture suites pass on Vite 8 and Vite 7.

I used Claude Code while investigating this. I reproduced the bugs and reviewed the fix myself.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] No new functionality, nothing to document.

### Changesets
- [x] The PR title explains the change.
