### PR TITLE
docs: fix internal links to config options

### DIFF
--- a/docs/config/browser/expect.md
+++ b/docs/config/browser/expect.md
@@ -101,7 +101,7 @@ receives an object with the following properties:
 
 - `screenshotDirectory: string`
 
-  The value provided to [`browser.expect.toMatchScreenshot.screenshotDirectory`](#browserexpecttomatchscreenshotscreenshotdirectory), if none is provided, its default value (`__screenshots__`).
+  The value provided to [`browser.expect.toMatchScreenshot.screenshotDirectory`](#browser-expect-tomatchscreenshot-screenshotdirectory), if none is provided, its default value (`__screenshots__`).
 
 - `root: string`
 

--- a/docs/guide/migration/index.md
+++ b/docs/guide/migration/index.md
@@ -296,7 +296,7 @@ vi.setSystemTime(0)
 Temporal.Now.instant().epochMilliseconds // 0 (was the real time in v4)
 ```
 
-`Temporal` is part of the default set of faked APIs, so it is controlled by [`fakeTimers.toFake`](/config/#faketimers-tofake) and [`fakeTimers.toNotFake`](/config/#faketimers-tonotfake). To keep `Temporal` native, add it to `toNotFake`:
+`Temporal` is part of the default set of faked APIs, so it is controlled by [`fakeTimers.toFake`](/config/faketimers#faketimers-tofake) and [`fakeTimers.toNotFake`](/config/faketimers#faketimers-tonotfake). To keep `Temporal` native, add it to `toNotFake`:
 
 ```ts
 vi.useFakeTimers({ toNotFake: ['Temporal'] })
@@ -464,7 +464,7 @@ test('renders', async () => {
 
 ## Glob Coverage Thresholds No Longer Inherit `perFile`
 
-`coverage.thresholds.perFile` previously applied to every threshold set, including files matched by glob-pattern thresholds. Glob patterns now control their own per-file checking and no longer inherit the top-level `perFile` — set `perFile` on each glob that needs it.
+[`coverage.thresholds.perFile`](/config/coverage#coverage-thresholds-perfile) previously applied to every threshold set, including files matched by glob-pattern thresholds. Glob patterns now control their own per-file checking and no longer inherit the top-level `perFile` — set `perFile` on each glob that needs it.
 
 ```ts [vitest.config.ts]
 export default defineConfig({

--- a/docs/guide/migration/index.md
+++ b/docs/guide/migration/index.md
@@ -485,7 +485,7 @@ export default defineConfig({
 
 ## Coverage `include` and `exclude` Match More Precisely
 
-[`coverage.include`](/config/coverage#coverage-include) and `coverage.exclude` were matched against absolute paths with picomatch's `contains` option, which matched many more files than intended. Patterns are now matched against each file's path relative to the project root, without `contains`, and a pattern with no glob wildcard is treated as a directory that matches everything inside it:
+[`coverage.include`](/config/coverage#coverage-include) and [`coverage.exclude`](/config/coverage#coverage-exclude) were matched against absolute paths with picomatch's `contains` option, which matched many more files than intended. Patterns are now matched against each file's path relative to the project root, without `contains`, and a pattern with no glob wildcard is treated as a directory that matches everything inside it:
 
 ```ts [vitest.config.ts]
 export default defineConfig({

--- a/docs/guide/migration/index.md
+++ b/docs/guide/migration/index.md
@@ -564,9 +564,9 @@ The `json` and `junit` reporters now write to a file by default instead of print
 
 ## `toMatchScreenshot` Now Uses a Dedicated Screenshot Directory Config
 
-Previously, reference screenshots for `toMatchScreenshot` did not correctly respect `browser.screenshotDirectory`. As a result, screenshots were saved in an unintended location when a custom directory was configured.
+Previously, reference screenshots for `toMatchScreenshot` did not correctly respect [`browser.screenshotDirectory`](/config/browser/screenshotdirectory). As a result, screenshots were saved in an unintended location when a custom directory was configured.
 
-This has now been fixed by introducing a dedicated option: `browser.expect.toMatchScreenshot.screenshotDirectory`. Its default value is `__screenshots__`.
+This has now been fixed by introducing a dedicated option: [`browser.expect.toMatchScreenshot.screenshotDirectory`](/config/browser/expect#browser-expect-tomatchscreenshot-screenshotdirectory). Its default value is `__screenshots__`.
 
 - If you did not set `browser.screenshotDirectory`, no changes are required.
 - If you did set `browser.screenshotDirectory`, you must now explicitly configure the new option:


### PR DESCRIPTION
### Description

Fixes internal links to config options in the Vitest 5 migration guide:

- link `coverage.exclude` and `coverage.thresholds.perFile` to their anchors
- fix broken `fakeTimers.toFake` / `fakeTimers.toNotFake` links that pointed to an empty `/config/#` segment
- link `browser.screenshotDirectory` and `browser.expect.toMatchScreenshot.screenshotDirectory`
- fix a broken same-page anchor link in `browser.expect.toMatchScreenshot.resolveScreenshotPath`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.