### PR TITLE
fix: show pending log on teardown (fix #11153)

### DIFF
--- a/packages/vitest/src/runtime/rpc.ts
+++ b/packages/vitest/src/runtime/rpc.ts
@@ -52,6 +52,12 @@ function withSafeTimers(fn: () => void) {
 }
 
 const promises = new Set<Promise<unknown>>()
+const pendingRpcArgs = new WeakMap<WorkerRPC, Map<string, unknown[][]>>()
+
+export function getPendingRpcArgs(rpc: WorkerRPC, method: string): unknown[] | undefined {
+  const calls = pendingRpcArgs.get(rpc)?.get(method)
+  return calls?.[calls.length - 1]
+}
 
 export async function rpcDone(): Promise<unknown[] | undefined> {
   if (!promises.size) {
@@ -79,7 +85,9 @@ export function createRuntimeRpc(
     'on' | 'post' | 'serialize' | 'deserialize'
   >,
 ): WorkerRPC {
-  return createSafeRpc(
+  const pendingCalls = new Map<string, unknown[][]>()
+
+  const rpc = createSafeRpc(
     createBirpc<RuntimeRPC, RunnerRPC>(
       {
         async onCancel(reason) {
@@ -91,10 +99,32 @@ export function createRuntimeRpc(
           'onCancel',
         ],
         timeout: -1,
+        onRequest(req, next) {
+          if (req.m !== 'onUserConsoleLog') {
+            return next()
+          }
+
+          const calls = pendingCalls.get(req.m) || []
+          calls.push(req.a)
+          pendingCalls.set(req.m, calls)
+
+          return next().finally(() => {
+            const index = calls.indexOf(req.a)
+            if (index !== -1) {
+              calls.splice(index, 1)
+            }
+            if (!calls.length) {
+              pendingCalls.delete(req.m)
+            }
+          })
+        },
         ...options,
       },
     ),
   )
+
+  pendingRpcArgs.set(rpc, pendingCalls)
+  return rpc
 }
 
 function createSafeRpc(rpc: WorkerRPC): WorkerRPC {

--- a/packages/vitest/src/runtime/rpc.ts
+++ b/packages/vitest/src/runtime/rpc.ts
@@ -99,35 +99,17 @@ export function createRuntimeRpc(
           'onCancel',
         ],
         timeout: -1,
-        onRequest(req, next) {
-          if (req.m !== 'onUserConsoleLog') {
-            return next()
-          }
-
-          const calls = pendingCalls.get(req.m) || []
-          calls.push(req.a)
-          pendingCalls.set(req.m, calls)
-
-          return next().finally(() => {
-            const index = calls.indexOf(req.a)
-            if (index !== -1) {
-              calls.splice(index, 1)
-            }
-            if (!calls.length) {
-              pendingCalls.delete(req.m)
-            }
-          })
-        },
         ...options,
       },
     ),
+    pendingCalls,
   )
 
   pendingRpcArgs.set(rpc, pendingCalls)
   return rpc
 }
 
-function createSafeRpc(rpc: WorkerRPC): WorkerRPC {
+function createSafeRpc(rpc: WorkerRPC, pendingCalls: Map<string, unknown[][]>): WorkerRPC {
   return new Proxy(rpc, {
     get(target, p, handler) {
       // keep $rejectPendingCalls as sync function
@@ -138,13 +120,33 @@ function createSafeRpc(rpc: WorkerRPC): WorkerRPC {
       const sendCall = get(target, p, handler)
       const safeSendCall = (...args: any[]) =>
         withSafeTimers(async () => {
-          const result = sendCall(...args)
-          promises.add(result)
+          const method = 'onUserConsoleLog'
+          const calls = p === method ? pendingCalls.get(method) || [] : undefined
+          if (calls) {
+            calls.push(args)
+            pendingCalls.set(method, calls)
+          }
+
           try {
-            return await result
+            const result = sendCall(...args)
+            promises.add(result)
+            try {
+              return await result
+            }
+            finally {
+              promises.delete(result)
+            }
           }
           finally {
-            promises.delete(result)
+            if (calls) {
+              const index = calls.indexOf(args)
+              if (index !== -1) {
+                calls.splice(index, 1)
+              }
+              if (!calls.length) {
+                pendingCalls.delete(method)
+              }
+            }
           }
         })
       safeSendCall.asEvent = sendCall.asEvent

--- a/packages/vitest/src/runtime/utils.ts
+++ b/packages/vitest/src/runtime/utils.ts
@@ -1,10 +1,27 @@
 import type { EvaluatedModules } from 'vite/module-runner'
+import type { UserConsoleLog } from '../types/general'
 import type { WorkerGlobalState } from '../types/worker'
 
 const NAME_WORKER_STATE = '__vitest_worker__'
 
 export class EnvironmentTeardownError extends Error {
   name = 'EnvironmentTeardownError'
+}
+
+export function createEnvironmentTeardownError(method: string, args?: unknown[]): EnvironmentTeardownError {
+  let message = `[vitest-worker]: Closing rpc while "${method}" was pending`
+
+  if (method === 'onUserConsoleLog') {
+    message += '\nThis can happen when an asynchronous operation is running after the test has finished.'
+      + '\nMake sure all asynchronous operations are awaited, or run with --detectAsyncLeaks to find leaking resources.'
+
+    const log = args?.[0] as UserConsoleLog | undefined
+    if (log && typeof log.content === 'string') {
+      message += `\n\nThe pending log was:\n${log.content}`
+    }
+  }
+
+  return new EnvironmentTeardownError(message)
 }
 
 export function getWorkerState(): WorkerGlobalState {

--- a/packages/vitest/src/runtime/worker.ts
+++ b/packages/vitest/src/runtime/worker.ts
@@ -6,8 +6,8 @@ import { GetterTracker } from './getter-tracker'
 import { setupInspect } from './inspector'
 import * as listeners from './listeners'
 import { VitestEvaluatedModules } from './moduleRunner/evaluatedModules'
-import { onCancel, rpcDone } from './rpc'
-import { EnvironmentTeardownError } from './utils'
+import { getPendingRpcArgs, onCancel, rpcDone } from './rpc'
+import { createEnvironmentTeardownError } from './utils'
 
 const resolvingModules = new Set<string>()
 
@@ -23,7 +23,7 @@ async function execute(method: 'run' | 'collect', ctx: ContextRPC, worker: Vites
     // do not close the RPC channel so that we can get the error messages sent to the main thread
     cleanups.push(async () => {
       await Promise.all(rpc.$rejectPendingCalls(({ method, reject }) => {
-        reject(new EnvironmentTeardownError(`[vitest-worker]: Closing rpc while "${method}" was pending`))
+        reject(createEnvironmentTeardownError(method, getPendingRpcArgs(rpc, method)))
       }))
     })
 

--- a/test/unit/test/pending-rpc.test.ts
+++ b/test/unit/test/pending-rpc.test.ts
@@ -36,4 +36,5 @@ test('includes a pending console log in the environment teardown error', async (
     The pending log was:
     late console log"
   `)
+  expect(getPendingRpcArgs(rpc, 'onUserConsoleLog')).toBeUndefined()
 })

--- a/test/unit/test/pending-rpc.test.ts
+++ b/test/unit/test/pending-rpc.test.ts
@@ -1,0 +1,39 @@
+import type { UserConsoleLog } from '../../../packages/vitest/src/types/general'
+import { expect, test } from 'vitest'
+import { createRuntimeRpc, getPendingRpcArgs } from '../../../packages/vitest/src/runtime/rpc'
+import { createEnvironmentTeardownError } from '../../../packages/vitest/src/runtime/utils'
+
+test('includes a pending console log in the environment teardown error', async () => {
+  const rpc = createRuntimeRpc({
+    on() {},
+    post() {},
+    serialize: data => data,
+    deserialize: data => data,
+  })
+  const log: UserConsoleLog = {
+    content: 'late console log',
+    type: 'stdout',
+    time: 123,
+    size: 1,
+  }
+
+  const pending = rpc.onUserConsoleLog(log).catch(error => error)
+  await Promise.resolve()
+
+  expect(getPendingRpcArgs(rpc, 'onUserConsoleLog')).toEqual([log])
+
+  await Promise.all(rpc.$rejectPendingCalls(({ method, reject }) => {
+    reject(createEnvironmentTeardownError(method, getPendingRpcArgs(rpc, method)))
+  }))
+
+  const error = await pending
+  expect(error).toBeInstanceOf(Error)
+  expect(error.message).toMatchInlineSnapshot(`
+    "[vitest-worker]: Closing rpc while \"onUserConsoleLog\" was pending
+    This can happen when an asynchronous operation is running after the test has finished.
+    Make sure all asynchronous operations are awaited, or run with --detectAsyncLeaks to find leaking resources.
+
+    The pending log was:
+    late console log"
+  `)
+})


### PR DESCRIPTION
Fixes #11153.

When a worker is torn down while an onUserConsoleLog RPC is still in flight, the teardown error currently reports only the method name. Preserve the pending console log arguments so the error includes the log content and points to --detectAsyncLeaks for finding work that outlives the test.

Other pending RPCs keep their existing teardown behavior.

## Verification

- CI=true ./node_modules/.bin/vitest run test/unit/test/pending-rpc.test.ts
- CI=true ./node_modules/.bin/vitest run test/reporters/reporter-error.test.ts
- NODE_OPTIONS=--max-old-space-size=8192 ./node_modules/.bin/tsc -p tsconfig.check.json --noEmit
- Targeted ESLint check
- Vitest package Rollup build

The full pnpm test:ci suite was not run locally. The last CI run passed all other checks; one unchanged virtual-module test fails only on Node 26 because it returns original instead of original-modified.